### PR TITLE
Add sleek dark mode and chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ You can click the Preview link to take a look at your changes.
 
 ## Dashboard Website
 
-The repository hosts a minimal dashboard example in the `website` folder. Open `website/index.html` in your browser to view several mock KPIs styled as cards with a bit of JavaScript that randomises their values on each load.
+The repository hosts an interactive dashboard example in the `website` folder. Open `website/index.html` in your browser to see animated KPIs, a dynamic sales chart powered by Chart.js and a dark mode toggle.

--- a/website/index.html
+++ b/website/index.html
@@ -1,38 +1,47 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My KPI Dashboard</title>
-    <link rel="stylesheet" href="style.css">
-</head>
-<body>
-    <header>
-        <h1>My Dashboard</h1>
+    <link rel="stylesheet" href="style.css" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="topbar">
+      <h1>My Dashboard</h1>
+      <div class="actions">
+        <button id="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+      </div>
     </header>
     <main>
-        <section class="kpi-grid">
-            <div class="kpi-card">
-                <h2>Total Sales</h2>
-                <p id="sales" class="kpi-value">$123,456</p>
-            </div>
-            <div class="kpi-card">
-                <h2>Active Users</h2>
-                <p id="users" class="kpi-value">789</p>
-            </div>
-            <div class="kpi-card">
-                <h2>Conversion Rate</h2>
-                <p id="conversion" class="kpi-value">5.6%</p>
-            </div>
-            <div class="kpi-card">
-                <h2>Support Tickets</h2>
-                <p id="tickets" class="kpi-value">12</p>
-            </div>
-        </section>
+      <section class="kpi-grid">
+        <div class="kpi-card">
+          <h2>Total Sales</h2>
+          <p id="sales" class="kpi-value">$123,456</p>
+        </div>
+        <div class="kpi-card">
+          <h2>Active Users</h2>
+          <p id="users" class="kpi-value">789</p>
+        </div>
+        <div class="kpi-card">
+          <h2>Conversion Rate</h2>
+          <p id="conversion" class="kpi-value">5.6%</p>
+        </div>
+        <div class="kpi-card">
+          <h2>Support Tickets</h2>
+          <p id="tickets" class="kpi-value">12</p>
+        </div>
+      </section>
+      <section class="chart-section">
+        <canvas id="salesChart"></canvas>
+      </section>
     </main>
-    <footer>
-        &copy; 2024 My KPI Dashboard
-    </footer>
+    <footer>&copy; 2024 My KPI Dashboard</footer>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="script.js"></script>
-</body>
+  </body>
 </html>

--- a/website/script.js
+++ b/website/script.js
@@ -1,10 +1,63 @@
-document.addEventListener('DOMContentLoaded', function () {
-    function rand(min, max) {
-        return Math.floor(Math.random() * (max - min + 1)) + min;
-    }
+document.addEventListener("DOMContentLoaded", () => {
+  const body = document.body;
+  const toggleBtn = document.getElementById("theme-toggle");
 
-    document.getElementById('sales').textContent = '$' + rand(100000, 200000).toLocaleString();
-    document.getElementById('users').textContent = rand(500, 1500);
-    document.getElementById('conversion').textContent = (Math.random() * 10).toFixed(1) + '%';
-    document.getElementById('tickets').textContent = rand(5, 30);
+  // Restore theme
+  if (localStorage.getItem("theme") === "dark") {
+    body.classList.add("dark");
+  }
+
+  toggleBtn.addEventListener("click", () => {
+    body.classList.toggle("dark");
+    localStorage.setItem(
+      "theme",
+      body.classList.contains("dark") ? "dark" : "light",
+    );
+  });
+
+  function rand(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+  function updateKPIs() {
+    document.getElementById("sales").textContent =
+      "$" + rand(100000, 200000).toLocaleString();
+    document.getElementById("users").textContent = rand(500, 1500);
+    document.getElementById("conversion").textContent =
+      (Math.random() * 10).toFixed(1) + "%";
+    document.getElementById("tickets").textContent = rand(5, 30);
+  }
+
+  updateKPIs();
+  setInterval(updateKPIs, 5000);
+
+  const labels = Array.from({ length: 12 }, (_, i) => `M${i + 1}`);
+  const data = labels.map(() => rand(5000, 20000));
+  const ctx = document.getElementById("salesChart");
+  new Chart(ctx, {
+    type: "line",
+    data: {
+      labels,
+      datasets: [
+        {
+          label: "Monthly Sales",
+          data,
+          fill: false,
+          borderColor: "#42a5f5",
+          tension: 0.3,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        legend: { display: false },
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+        },
+      },
+    },
+  });
 });

--- a/website/style.css
+++ b/website/style.css
@@ -1,44 +1,72 @@
-body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 0;
-    background: #f2f5f9;
-    color: #333;
+:root {
+  --bg: #f2f5f9;
+  --text: #333;
+  --card-bg: #fff;
+  --primary: #283593;
 }
 
-header {
-    background: #283593;
-    color: #fff;
-    padding: 1rem;
-    text-align: center;
+body.dark {
+  --bg: #121212;
+  --text: #eee;
+  --card-bg: #1e1e1e;
+  --primary: #90caf9;
+}
+
+body {
+  font-family: "Roboto", sans-serif;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  transition:
+    background 0.3s,
+    color 0.3s;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  background: var(--primary);
+  color: #fff;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .kpi-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-    padding: 2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  padding: 2rem;
 }
 
 .kpi-card {
-    background: #fff;
-    padding: 1rem;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    text-align: center;
+  background: var(--card-bg);
+  padding: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+  text-align: center;
+  transition: transform 0.2s;
+}
+
+.kpi-card:hover {
+  transform: translateY(-4px);
 }
 
 .kpi-value {
-    font-size: 2rem;
-    margin: 0.5rem 0;
+  font-size: 2rem;
+  margin: 0.5rem 0;
+}
+
+.chart-section {
+  padding: 2rem;
 }
 
 footer {
-    background: #283593;
-    color: #fff;
-    text-align: center;
-    padding: 1rem;
-    position: fixed;
-    width: 100%;
-    bottom: 0;
+  margin-top: auto;
+  background: var(--primary);
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
 }


### PR DESCRIPTION
## Summary
- modernize the dashboard layout
- add dark theme toggle
- animate KPI updates
- include a Chart.js sales chart

## Testing
- `npx prettier --check README.md website/index.html website/style.css website/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6842c23297a08325bbe02fe7349a17b1